### PR TITLE
Add missing TypeScript type definitions for 'source-map' & 'uglify-js' [#43]

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,8 @@
     "@types/hammerjs": "^2.0.32",
     "@types/jasmine": "^2.2.33",
     "@types/node": "^6.0.38",
+    "@types/source-map": "0.5.0",
+    "@types/uglify-js": "2.6.28",
     "@types/webpack": "^1.12.34",
     "angular2-hmr": "^0.8.1",
     "autoprefixer": "^6.3.6",


### PR DESCRIPTION
My first Github pull request.