### PR TITLE
Fixed protractor webdriver imports @see https://github.com/angular/pr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "phantomjs-polyfill": "0.0.2",
     "phantomjs-prebuilt": "^2.1.6",
     "postcss-loader": "^0.8.2",
-    "protractor": "^4.0.9",
+    "protractor": "^4.0.14",
     "protractor-cucumber-framework": "^0.6.0",
     "raw-loader": "0.5.1",
     "remap-istanbul": "^0.5.1",

--- a/test/e2e/authentication/authentication.page.ts
+++ b/test/e2e/authentication/authentication.page.ts
@@ -1,5 +1,5 @@
 import { browser } from 'protractor';
-import Promise = webdriver.promise.Promise;
+import { promise as wdpromise } from 'selenium-webdriver';
 
 export class AuthenticationPageObject {
 
@@ -16,27 +16,27 @@ export class AuthenticationPageObject {
 
   }
 
-  openApp(): Promise<void> {
+  openApp(): wdpromise.Promise<void> {
     return browser.get('');
   }
 
-  goToLoginPage(): Promise<void> {
+  goToLoginPage(): wdpromise.Promise<void> {
     return browser.get(`${this.pages['login']}`);
   }
 
-  goToRegisterPage(): Promise<void> {
+  goToRegisterPage(): wdpromise.Promise<void> {
     return browser.get(`${this.pages['register']}`);
   }
 
-  goToForgotPasswordPage(): Promise<void> {
+  goToForgotPasswordPage(): wdpromise.Promise<void> {
     return browser.get(`${this.pages['forgotPassword']}`);
   }
 
-  goToSetNewPasswordPage(id?: string, nonce?: string): Promise<void> {
+  goToSetNewPasswordPage(id?: string, nonce?: string): wdpromise.Promise<void> {
     return browser.get(`${this.pages['setNewPassword']}?id=${id}&nonce=${nonce}`);
   }
 
-  getCurrentUrl(): Promise<string> {
+  getCurrentUrl(): wdpromise.Promise<string> {
     return browser.getCurrentUrl();
   }
 }

--- a/test/e2e/authentication/forgot-password/forgotPassword.page.ts
+++ b/test/e2e/authentication/forgot-password/forgotPassword.page.ts
@@ -1,5 +1,5 @@
 import { element, by, protractor, ElementArrayFinder } from 'protractor';
-import Promise = webdriver.promise.Promise;
+import { promise as wdpromise } from 'selenium-webdriver';
 
 export class ForgotPasswordPageObject {
 
@@ -23,19 +23,19 @@ export class ForgotPasswordPageObject {
 
   }
 
-  setEmail(value: string): Promise<void> {
+  setEmail(value: string): wdpromise.Promise<void> {
     return this.emailInput.clear().sendKeys(value);
   }
 
-  getTitle(): Promise<string> {
+  getTitle(): wdpromise.Promise<string> {
     return this.title.getText();
   }
 
-  submitForm(): Promise<void> {
+  submitForm(): wdpromise.Promise<void> {
     return this.submitButton.sendKeys(protractor.Key.ENTER);
   }
 
-  formIsValid(): Promise<boolean> {
+  formIsValid(): wdpromise.Promise<boolean> {
     return this.getAllErrorMessages().count().then(value => {
       return value === 0;
     });

--- a/test/e2e/authentication/login/login.page.ts
+++ b/test/e2e/authentication/login/login.page.ts
@@ -1,5 +1,5 @@
 import { element, by, protractor, ElementArrayFinder } from 'protractor';
-import Promise = webdriver.promise.Promise;
+import { promise as wdpromise } from 'selenium-webdriver';
 
 export class LoginPageObject {
 
@@ -25,31 +25,31 @@ export class LoginPageObject {
 
     }
 
-    navigateToForgotPasswordPage(): Promise<void> {
+    navigateToForgotPasswordPage(): wdpromise.Promise<void> {
         return this.goToForgotPasswordLink.click();
     }
 
-    navigateToRegisterPage(): Promise<void> {
+    navigateToRegisterPage(): wdpromise.Promise<void> {
         return this.goToRegisterLink.click();
     }
 
-    setEmail(value: string): Promise<void> {
+    setEmail(value: string): wdpromise.Promise<void> {
         return this.emailInput.clear().sendKeys(value);
     }
 
-    setPassword(value: string): Promise<void> {
+    setPassword(value: string): wdpromise.Promise<void> {
         return this.passwordInput.clear().sendKeys(value);
     }
 
-    getTitle(): Promise<string> {
+    getTitle(): wdpromise.Promise<string> {
         return this.title.getText();
     }
 
-    submitForm(): Promise<void> {
+    submitForm(): wdpromise.Promise<void> {
         return this.submitButton.sendKeys(protractor.Key.ENTER);
     }
 
-    formIsValid(): Promise<boolean> {
+    formIsValid(): wdpromise.Promise<boolean> {
         return this.getAllErrorMessages().count().then(value => {
             return value === 0;
         });

--- a/test/e2e/authentication/register/register.page.ts
+++ b/test/e2e/authentication/register/register.page.ts
@@ -1,5 +1,5 @@
 import { element, by, protractor, ElementArrayFinder } from 'protractor';
-import Promise = webdriver.promise.Promise;
+import { promise as wdpromise } from 'selenium-webdriver';
 
 export class RegisterPageObject {
 
@@ -29,31 +29,31 @@ export class RegisterPageObject {
 
   }
 
-  setName(value: string): Promise<void> {
+  setName(value: string): wdpromise.Promise<void> {
     return this.nameInput.clear().sendKeys(value);
   }
 
-  setEmail(value: string): Promise<void> {
+  setEmail(value: string): wdpromise.Promise<void> {
     return this.emailInput.clear().sendKeys(value);
   }
 
-  setPassword(value: string): Promise<void> {
+  setPassword(value: string): wdpromise.Promise<void> {
     return this.passwordInput.clear().sendKeys(value);
   }
 
-  setRepeatPassword(value: string): Promise<void> {
+  setRepeatPassword(value: string): wdpromise.Promise<void> {
     return this.repeatPasswordInput.clear().sendKeys(value);
   }
 
-  getTitle(): Promise<string> {
+  getTitle(): wdpromise.Promise<string> {
     return this.title.getText();
   }
 
-  submitForm(): Promise<void> {
+  submitForm(): wdpromise.Promise<void> {
     return this.submitButton.sendKeys(protractor.Key.ENTER);
   }
 
-  formIsValid(): Promise<boolean> {
+  formIsValid(): wdpromise.Promise<boolean> {
     return this.getAllErrorMessages().count().then(value => {
       return value === 0;
     });

--- a/test/e2e/authentication/set-new-password/setNewPassword.page.ts
+++ b/test/e2e/authentication/set-new-password/setNewPassword.page.ts
@@ -1,5 +1,5 @@
 import { browser, element, by, protractor, ElementArrayFinder } from 'protractor';
-import Promise = webdriver.promise.Promise;
+import { promise as wdpromise } from 'selenium-webdriver';
 
 export class SetNewPasswordPageObject {
 
@@ -25,35 +25,35 @@ export class SetNewPasswordPageObject {
 
   }
 
-  setPassword(value: string): Promise<void> {
+  setPassword(value: string): wdpromise.Promise<void> {
     return this.passwordInput.clear().sendKeys(value);
   }
 
-  setRepeatPassword(value: string): Promise<void> {
+  setRepeatPassword(value: string): wdpromise.Promise<void> {
     return this.repeatPasswordInput.clear().sendKeys(value);
   }
 
-  getTitle(): Promise<string> {
+  getTitle(): wdpromise.Promise<string> {
     return this.title.getText();
   }
 
-  submitForm(): Promise<void> {
+  submitForm(): wdpromise.Promise<void> {
     return this.submitButton.sendKeys(protractor.Key.ENTER);
   }
 
-  hasAlertMessages(): Promise<boolean> {
+  hasAlertMessages(): wdpromise.Promise<boolean> {
     return this.getAllAlerts().count().then(value => {
       return value > 0;
     });
   }
 
-  hasFormElements(): Promise<boolean> {
+  hasFormElements(): wdpromise.Promise<boolean> {
     return this.getAllFormElements().count().then(value => {
       return value > 0;
     });
   }
 
-  formIsValid(): Promise<boolean> {
+  formIsValid(): wdpromise.Promise<boolean> {
     return this.getAllErrorMessages().count().then(value => {
       return value === 0;
     });

--- a/test/e2e/speakerregistration/stepone.page.ts
+++ b/test/e2e/speakerregistration/stepone.page.ts
@@ -1,5 +1,5 @@
 import { browser, element, by, protractor, ElementArrayFinder } from 'protractor';
-import Promise = webdriver.promise.Promise;
+import { promise as wdpromise } from 'selenium-webdriver';
 
 export class StepOnePageObject {
 

--- a/test/e2e/speakerregistration/stepthree.page.ts
+++ b/test/e2e/speakerregistration/stepthree.page.ts
@@ -1,5 +1,5 @@
 import { browser, element, by, protractor, ElementArrayFinder } from 'protractor';
-import Promise = webdriver.promise.Promise;
+import { promise as wdpromise } from 'selenium-webdriver';
 
 export class StepThreePageObject {
 
@@ -7,5 +7,5 @@ export class StepThreePageObject {
     constructor() {
 
     }
-    
+
 }

--- a/test/e2e/speakerregistration/steptwo.page.ts
+++ b/test/e2e/speakerregistration/steptwo.page.ts
@@ -1,5 +1,5 @@
 import { browser, element, by, protractor, ElementArrayFinder } from 'protractor';
-import Promise = webdriver.promise.Promise;
+import { promise as wdpromise } from 'selenium-webdriver';
 
 export class StepTwoPageObject {
 
@@ -7,5 +7,5 @@ export class StepTwoPageObject {
     constructor() {
 
     }
-    
+
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
       "es6"
     ],
     "types": [
+      "selenium-webdriver",
       "hammerjs",
       "jasmine",
       "node",


### PR DESCRIPTION
Fixed due bug in protactor.

@see https://github.com/angular/protractor/issues/3878
@see http://stackoverflow.com/questions/41238376/angular2-npm-install-didnt-find-namespace-webdriver

Steps to reproduce before PR:
1. Do a clean install of the master branch
2. Npm install
3. Npm run start
4. Npm run e2e
5. e2e fails due to 'namespace webdriver not found'

